### PR TITLE
fix: クリップボード読み込み後のセーブ→ロードで COPY が失敗するバグを修正

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -249,7 +249,7 @@ ipcMain.handle("read-info", () => {
       result.material = parser.parseString(data.material.raw);
       result.target = parser.parseBer(data.target.raw);
       result.yLine = parser.parseBer(data.yLine.raw);
-      result.rawEffect = data.effectList.raw;
+      result.rawEffect = Array.from(data.effectList.raw);
 
       return result;
     })
@@ -268,7 +268,9 @@ ipcMain.handle("write-anime", (event, { frameList, info }) => {
   anime.yLine.data = parseInt(info.yLine);
 
   if (info.rawEffect) {
-    anime.effectList.raw = info.rawEffect;
+    anime.effectList.raw = Array.isArray(info.rawEffect)
+      ? info.rawEffect
+      : Object.values(info.rawEffect);
   }
 
   // フレームデータの生成


### PR DESCRIPTION
## 概要

Closes #8

「クリップボードから読み込み」を使った後にセーブ→ロードすると COPY が失敗するバグを修正した。

## 原因

`read-info` IPC ハンドラが `data.effectList.raw`（`Uint8Array`）をそのまま `rawEffect` として返していた。

`Uint8Array` を `JSON.stringify` すると `{"0":1,"1":2,...}` の plain object に変換されてしまい、ロード後に `JSON.parse` で復元したときに `length` プロパティや iterator を持たない object になる。その状態で COPY（`write-anime`）を呼ぶと、tk2k-clipdata の builder が `raw.length` や `...raw` を参照してエラーになっていた。

## 修正内容

- `read-info`: `Array.from()` で `Uint8Array` → 通常の Array に変換してから返す
- `write-anime`: `Array.isArray` チェックを追加し、既存の壊れたファイル（`{"0":1,...}` 形式）でも `Object.values()` で配列化して対応

## テスト

`electron.js` はメインプロセスのため Jest 対象外。再現手順に従い実機で動作確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)