### PR TITLE
fix: electron.js を public/ から electron/ へ移動し electron-builder のエントリエラーを修正

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -9,8 +9,8 @@ const {
 const path = require("path");
 const fs = require("fs");
 const { tk2k, getEmptyData, write, read, parser } = require("tk2k-clipdata");
-const i18n = require("../electron/configs/i18next.config");
-const menuTemplate = require("../electron/menuTemplate");
+const i18n = require("./configs/i18next.config");
+const menuTemplate = require("./menuTemplate");
 const ElectronStore = require("electron-store");
 
 const store = new ElectronStore();
@@ -69,7 +69,7 @@ const createWindow = () => {
     useContentSize: true,
     title: "Effect Conductor",
     webPreferences: {
-      preload: path.resolve(__dirname, "../electron/preload.js"),
+      preload: path.resolve(__dirname, "./preload.js"),
       additionalArguments: [
         `storedLanguage=${store.get("lang", "ja")}`
       ]

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vite": "^8.0.9",
     "vitest": "^4.1.4"
   },
-  "main": "public/electron.js",
+  "main": "electron/electron.js",
   "build": {
     "appId": "com.lpre-ys.effedct-conductor",
     "productName": "EffectConductor",


### PR DESCRIPTION
## Summary

- `public/electron.js` を `electron/electron.js` に移動
- 内部の require パスを `../electron/` → `./` に修正
- `package.json` の `main` フィールドを `electron/electron.js` に更新

Vite 移行後、`electron-builder` の `build.files` に `public/` が含まれていなかったため、asar にエントリファイルが入らずビルドが失敗していた。`electron/` フォルダに移動することで既存の `electron/**/*` 設定でカバーされるようになる。

## Test plan

- [x] `npm run release` でビルドが成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)