### PR TITLE
feat: タイムライン一括設定ダイアログとCtrl+A全選択を実装

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import Export from "./component/Export";
 import Material from "./component/Material";
 import Player from "./component/Player";
 import Timeline from "./component/Timeline";
-import { loadCelList, resetCelList } from "./slice/celListSlice";
+import { loadCelList, resetCelList, selectAllCels } from "./slice/celListSlice";
 import { loadFrameConfig, resetFrameConfig } from "./slice/frameSlice";
 import { loadInfo, resetInfo } from "./slice/infoSlice";
 import { loadMaterial, resetMaterial } from "./slice/materialSlice";
@@ -40,6 +40,9 @@ class App extends React.Component {
     } else if (e.ctrlKey && (e.key.toLowerCase() === 'y' || (e.shiftKey && e.key.toLowerCase() === 'z'))) {
       e.preventDefault();
       this.props.redo();
+    } else if (e.ctrlKey && e.key.toLowerCase() === 'a') {
+      e.preventDefault();
+      this.props.selectAll();
     }
   }
   componentDidMount() {
@@ -175,6 +178,7 @@ const mapDispatchToProps = (dispatch) => {
     },
     undo: () => dispatch(undoAction()),
     redo: () => dispatch(redoAction()),
+    selectAll: () => dispatch(selectAllCels()),
   };
 };
 

--- a/src/component/BulkConfigDialog.jsx
+++ b/src/component/BulkConfigDialog.jsx
@@ -1,20 +1,23 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from "@emotion/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { bulkUpdateParams } from "../slice/celListSlice";
 
 const PARAMS = [
-  { key: "x",       labelKey: "configs.x",             section: "basic" },
-  { key: "y",       labelKey: "configs.y",             section: "basic" },
-  { key: "scale",   labelKey: "configs.scale",         section: "basic" },
-  { key: "opacity", labelKey: "configs.opacity",       section: "basic" },
-  { key: "red",     labelKey: "configs.color.red",     section: "color" },
-  { key: "green",   labelKey: "configs.color.green",   section: "color" },
-  { key: "blue",    labelKey: "configs.color.blue",    section: "color" },
-  { key: "tkSat",   labelKey: "configs.color.satulation", section: "color" },
+  { key: "x",       labelKey: "configs.x",                  section: "basic" },
+  { key: "y",       labelKey: "configs.y",                  section: "basic" },
+  { key: "scale",   labelKey: "configs.scale",              section: "basic" },
+  { key: "opacity", labelKey: "configs.opacity",            section: "basic" },
+  { key: "red",     labelKey: "configs.color.red",          section: "color", colorMode: "rgb" },
+  { key: "green",   labelKey: "configs.color.green",        section: "color", colorMode: "rgb" },
+  { key: "blue",    labelKey: "configs.color.blue",         section: "color", colorMode: "rgb" },
+  { key: "hue",     labelKey: "configs.color.hsvHue",       section: "color", colorMode: "hsv" },
+  { key: "sat",     labelKey: "configs.color.hsvSat",       section: "color", colorMode: "hsv" },
+  { key: "val",     labelKey: "configs.color.hsvVal",       section: "color", colorMode: "hsv" },
+  { key: "tkSat",   labelKey: "configs.color.satulation",   section: "color", colorMode: "always" },
 ];
 
 const UPDATE_TYPES = ["overwrite", "add", "multiply"];
@@ -29,7 +32,19 @@ const makeInitialParamState = (updateType) =>
 export default function BulkConfigDialog({ onClose }) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const celList = useSelector((state) => state.celList.list);
   const selectedIndices = useSelector((state) => state.celList.selectedIndices);
+
+  const hsvMode = useMemo(() => {
+    const flags = selectedIndices
+      .map((i) => celList[i])
+      .filter(Boolean)
+      .map((cel) => cel.hsv?.isHsv ?? false);
+    if (flags.length === 0) return "rgb";
+    if (flags.every((f) => f === true))  return "hsv";
+    if (flags.every((f) => f === false)) return "rgb";
+    return "mixed";
+  }, [celList, selectedIndices]);
 
   const [updateType, setUpdateType] = useState("overwrite");
   const [paramState, setParamState] = useState(() => makeInitialParamState("overwrite"));
@@ -59,8 +74,20 @@ export default function BulkConfigDialog({ onClose }) {
   };
 
   const handleApply = () => {
+    const activeKeys = new Set(
+      PARAMS
+        .filter((p) => {
+          if (!p.colorMode) return true;
+          if (p.colorMode === "always") return true;
+          if (p.colorMode === "rgb" && hsvMode === "rgb") return true;
+          if (p.colorMode === "hsv" && hsvMode === "hsv") return true;
+          return false;
+        })
+        .map((p) => p.key)
+    );
     const params = {};
     for (const [key, { enabled, value }] of Object.entries(paramState)) {
+      if (!activeKeys.has(key)) continue;
       if (enabled) {
         const parsed = parseFloat(value);
         if (!isNaN(parsed)) params[key] = parsed;
@@ -73,7 +100,13 @@ export default function BulkConfigDialog({ onClose }) {
   };
 
   const basicParams = PARAMS.filter((p) => p.section === "basic");
-  const colorParams = PARAMS.filter((p) => p.section === "color");
+  const colorParams = PARAMS.filter((p) => {
+    if (p.section !== "color") return false;
+    if (!p.colorMode || p.colorMode === "always") return true;
+    if (p.colorMode === "rgb" && hsvMode === "rgb") return true;
+    if (p.colorMode === "hsv" && hsvMode === "hsv") return true;
+    return false;
+  });
 
   return (
     <div css={styles.overlay} onMouseDown={onClose} data-testid="bulk-config-overlay">
@@ -107,6 +140,9 @@ export default function BulkConfigDialog({ onClose }) {
 
         <div css={styles.section}>
           <p css={styles.sectionLabel}>{t("bulkConfigDialog.color")}</p>
+          {hsvMode === "mixed" && (
+            <p css={styles.mixedMessage}>{t("bulkConfigDialog.hsvMixed")}</p>
+          )}
           {colorParams.map(({ key, labelKey }) => (
             <ParamRow
               key={key}
@@ -268,5 +304,10 @@ const styles = {
     :hover {
       background: #455a64;
     }
+  `,
+  mixedMessage: css`
+    margin: 0.3em 0;
+    font-size: 0.8rem;
+    color: #f57c00;
   `,
 };

--- a/src/component/BulkConfigDialog.jsx
+++ b/src/component/BulkConfigDialog.jsx
@@ -1,0 +1,272 @@
+/** @jsxImportSource @emotion/react */
+
+import { css } from "@emotion/react";
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { bulkUpdateParams } from "../slice/celListSlice";
+
+const PARAMS = [
+  { key: "x",       labelKey: "configs.x",             section: "basic" },
+  { key: "y",       labelKey: "configs.y",             section: "basic" },
+  { key: "scale",   labelKey: "configs.scale",         section: "basic" },
+  { key: "opacity", labelKey: "configs.opacity",       section: "basic" },
+  { key: "red",     labelKey: "configs.color.red",     section: "color" },
+  { key: "green",   labelKey: "configs.color.green",   section: "color" },
+  { key: "blue",    labelKey: "configs.color.blue",    section: "color" },
+  { key: "tkSat",   labelKey: "configs.color.satulation", section: "color" },
+];
+
+const UPDATE_TYPES = ["overwrite", "add", "multiply"];
+
+const getDefaultValue = (updateType) => (updateType === "multiply" ? 1 : 0);
+
+const makeInitialParamState = (updateType) =>
+  Object.fromEntries(
+    PARAMS.map(({ key }) => [key, { enabled: false, value: String(getDefaultValue(updateType)) }])
+  );
+
+export default function BulkConfigDialog({ onClose }) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const selectedIndices = useSelector((state) => state.celList.selectedIndices);
+
+  const [updateType, setUpdateType] = useState("overwrite");
+  const [paramState, setParamState] = useState(() => makeInitialParamState("overwrite"));
+
+  const handleUpdateTypeChange = (type) => {
+    const defaultValue = String(getDefaultValue(type));
+    setUpdateType(type);
+    setParamState((prev) =>
+      Object.fromEntries(
+        Object.entries(prev).map(([key, v]) => [key, { ...v, value: defaultValue }])
+      )
+    );
+  };
+
+  const handleToggleEnabled = (key) => {
+    setParamState((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], enabled: !prev[key].enabled },
+    }));
+  };
+
+  const handleValueChange = (key, raw) => {
+    setParamState((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], value: raw },
+    }));
+  };
+
+  const handleApply = () => {
+    const params = {};
+    for (const [key, { enabled, value }] of Object.entries(paramState)) {
+      if (enabled) {
+        const parsed = parseFloat(value);
+        if (!isNaN(parsed)) params[key] = parsed;
+      }
+    }
+    if (Object.keys(params).length > 0) {
+      dispatch(bulkUpdateParams({ indices: selectedIndices, params, updateType }));
+    }
+    onClose();
+  };
+
+  const basicParams = PARAMS.filter((p) => p.section === "basic");
+  const colorParams = PARAMS.filter((p) => p.section === "color");
+
+  return (
+    <div css={styles.overlay} onMouseDown={onClose} data-testid="bulk-config-overlay">
+      <div css={styles.dialog} onMouseDown={(e) => e.stopPropagation()}>
+        <h2 css={styles.title}>{t("bulkConfigDialog.title")}</h2>
+
+        <div css={styles.updateTypeRow}>
+          {UPDATE_TYPES.map((type) => (
+            <button
+              key={type}
+              css={[styles.typeButton, updateType === type && styles.typeButtonActive]}
+              onClick={() => handleUpdateTypeChange(type)}
+            >
+              {t(`bulkConfigDialog.${type}`)}
+            </button>
+          ))}
+        </div>
+
+        <div css={styles.section}>
+          <p css={styles.sectionLabel}>{t("bulkConfigDialog.basic")}</p>
+          {basicParams.map(({ key, labelKey }) => (
+            <ParamRow
+              key={key}
+              label={t(labelKey)}
+              state={paramState[key]}
+              onToggle={() => handleToggleEnabled(key)}
+              onChange={(raw) => handleValueChange(key, raw)}
+            />
+          ))}
+        </div>
+
+        <div css={styles.section}>
+          <p css={styles.sectionLabel}>{t("bulkConfigDialog.color")}</p>
+          {colorParams.map(({ key, labelKey }) => (
+            <ParamRow
+              key={key}
+              label={t(labelKey)}
+              state={paramState[key]}
+              onToggle={() => handleToggleEnabled(key)}
+              onChange={(raw) => handleValueChange(key, raw)}
+            />
+          ))}
+        </div>
+
+        <div css={styles.footer}>
+          <button css={[styles.footerButton, styles.applyButton]} onClick={handleApply}>
+            {t("bulkConfigDialog.apply")}
+          </button>
+          <button css={styles.footerButton} onClick={onClose}>
+            {t("bulkConfigDialog.cancel")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ParamRow({ label, state, onToggle, onChange }) {
+  return (
+    <label css={styles.paramRow}>
+      <input
+        type="checkbox"
+        checked={state.enabled}
+        onChange={onToggle}
+        css={styles.checkbox}
+      />
+      <span css={styles.paramLabel}>{label}</span>
+      <input
+        type="number"
+        value={state.value}
+        disabled={!state.enabled}
+        onChange={(e) => onChange(e.target.value)}
+        css={styles.input}
+      />
+    </label>
+  );
+}
+
+const styles = {
+  overlay: css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  `,
+  dialog: css`
+    background: #fafafa;
+    border-radius: 8px;
+    padding: 1.5em;
+    min-width: 260px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  `,
+  title: css`
+    margin: 0 0 1em;
+    font-size: 1.1rem;
+    color: #212121;
+  `,
+  updateTypeRow: css`
+    display: flex;
+    gap: 0.3em;
+    margin-bottom: 1em;
+  `,
+  typeButton: css`
+    border: 1px solid #bdbdbd;
+    padding: 0.3em 0.8em;
+    font-size: 0.9rem;
+    border-radius: 4px;
+    cursor: pointer;
+    background: #e0e0e0;
+    color: #424242;
+    :hover {
+      background: #757575;
+      color: #fafafa;
+    }
+  `,
+  typeButtonActive: css`
+    background: #546e7a;
+    color: #fafafa;
+    border-color: #546e7a;
+    :hover {
+      background: #455a64;
+    }
+  `,
+  section: css`
+    margin-bottom: 0.8em;
+  `,
+  sectionLabel: css`
+    margin: 0 0 0.4em;
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: #616161;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.2em;
+  `,
+  paramRow: css`
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    margin: 0.3em 0;
+    cursor: pointer;
+  `,
+  checkbox: css`
+    cursor: pointer;
+  `,
+  paramLabel: css`
+    width: 4em;
+    font-size: 0.9rem;
+    color: #424242;
+  `,
+  input: css`
+    width: 6em;
+    padding: 0.2em 0.4em;
+    font-size: 0.9rem;
+    border: 1px solid #bdbdbd;
+    border-radius: 4px;
+    :disabled {
+      background: #eeeeee;
+      color: #9e9e9e;
+      cursor: not-allowed;
+    }
+  `,
+  footer: css`
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5em;
+    margin-top: 1em;
+    border-top: 1px solid #e0e0e0;
+    padding-top: 0.8em;
+  `,
+  footerButton: css`
+    border: none;
+    padding: 0.4em 1.2em;
+    font-size: 0.95rem;
+    border-radius: 4px;
+    cursor: pointer;
+    background: #e0e0e0;
+    color: #424242;
+    :hover {
+      background: #757575;
+      color: #fafafa;
+    }
+  `,
+  applyButton: css`
+    background: #546e7a;
+    color: #fafafa;
+    :hover {
+      background: #455a64;
+    }
+  `,
+};

--- a/src/component/BulkConfigDialog.test.jsx
+++ b/src/component/BulkConfigDialog.test.jsx
@@ -6,14 +6,18 @@ import BulkConfigDialog from "./BulkConfigDialog";
 const nonFixed = { from: 10, to: 20, cycle: 0, isRoundTrip: false, easing: "easeLinear", easingAdd: "" };
 const fixed = { from: 100, to: 100, cycle: 0, isRoundTrip: false, easing: "fixed", easingAdd: "" };
 
-const makeCel = () => ({
+const makeCel = (isHsv = false) => ({
   x: { ...nonFixed },
   y: { ...nonFixed },
   scale: { ...nonFixed, from: 100, to: 100 },
   opacity: { ...nonFixed, from: 0, to: 0 },
-  red: { ...fixed },
+  red:   { ...fixed },
   green: { ...fixed },
-  blue: { ...fixed },
+  blue:  { ...fixed },
+  hsv:   { min: 0, max: 100, isHsv },
+  hue:   { ...fixed, from: 0,   to: 0   },
+  sat:   { ...fixed, from: 0,   to: 0   },
+  val:   { ...fixed, from: 100, to: 100 },
   tkSat: { ...fixed },
   frame: { start: 1, volume: 10 },
 });
@@ -99,5 +103,81 @@ describe("BulkConfigDialog", () => {
 
     userEvent.click(screen.getByTestId("bulk-config-overlay"));
     expect(onClose).toBeCalled();
+  });
+
+  test("全セルが RGB モードのとき red/green/blue が表示され hue は表示されない", () => {
+    const state = {
+      celList: { celIndex: 0, selectedIndices: [0, 1], drawKey: 0, list: [makeCel(false), makeCel(false)] },
+    };
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: state });
+    expect(screen.getByText("赤")).toBeInTheDocument();
+    expect(screen.getByText("緑")).toBeInTheDocument();
+    expect(screen.getByText("青")).toBeInTheDocument();
+    expect(screen.queryByText("H. 色相")).not.toBeInTheDocument();
+  });
+
+  test("全セルが HSV モードのとき hue/sat/val が表示され red は表示されない", () => {
+    const state = {
+      celList: { celIndex: 0, selectedIndices: [0], drawKey: 0, list: [makeCel(true)] },
+    };
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: state });
+    expect(screen.getByText("H. 色相")).toBeInTheDocument();
+    expect(screen.getByText("S. 彩度")).toBeInTheDocument();
+    expect(screen.getByText("V. 明度")).toBeInTheDocument();
+    expect(screen.queryByText("赤")).not.toBeInTheDocument();
+  });
+
+  test("ON/OFF 混在のとき混在メッセージが表示され red も hue も表示されない", () => {
+    const state = {
+      celList: { celIndex: 0, selectedIndices: [0, 1], drawKey: 0, list: [makeCel(false), makeCel(true)] },
+    };
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: state });
+    expect(screen.getByText(/HSVモードが混在/)).toBeInTheDocument();
+    expect(screen.queryByText("赤")).not.toBeInTheDocument();
+    expect(screen.queryByText("H. 色相")).not.toBeInTheDocument();
+  });
+
+  test("混在モードでも tkSat（彩度）は表示される", () => {
+    const state = {
+      celList: { celIndex: 0, selectedIndices: [0, 1], drawKey: 0, list: [makeCel(false), makeCel(true)] },
+    };
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: state });
+    expect(screen.getByText("彩度")).toBeInTheDocument();
+  });
+
+  test("混在モードで適用すると tkSat は更新され red と hue は変わらない", () => {
+    const state = {
+      celList: { celIndex: 0, selectedIndices: [0, 1], drawKey: 0, list: [makeCel(false), makeCel(true)] },
+    };
+    const { store } = renderWithProviders(
+      <BulkConfigDialog onClose={vi.fn()} />,
+      { preloadedState: state }
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    userEvent.click(checkboxes[4]); // tkSat チェック（basic 4 個の後、混在時は tkSat のみ）
+
+    userEvent.click(screen.getByText("適用"));
+
+    expect(store.getState().celList.list[0].tkSat.from).toBe(0);
+    expect(store.getState().celList.list[0].red.from).toBe(100);
+  });
+
+  test("HSV モードで適用すると hue が更新され red は変わらない", () => {
+    const state = {
+      celList: { celIndex: 0, selectedIndices: [0], drawKey: 0, list: [makeCel(true)] },
+    };
+    const { store } = renderWithProviders(
+      <BulkConfigDialog onClose={vi.fn()} />,
+      { preloadedState: state }
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    userEvent.click(checkboxes[4]); // hue チェック（basic 4 個の後）
+
+    userEvent.click(screen.getByText("適用"));
+
+    expect(store.getState().celList.list[0].hue.from).toBe(0);
+    expect(store.getState().celList.list[0].red.from).toBe(100); // 変わらない
   });
 });

--- a/src/component/BulkConfigDialog.test.jsx
+++ b/src/component/BulkConfigDialog.test.jsx
@@ -1,0 +1,103 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../util/renderWithProviders";
+import BulkConfigDialog from "./BulkConfigDialog";
+
+const nonFixed = { from: 10, to: 20, cycle: 0, isRoundTrip: false, easing: "easeLinear", easingAdd: "" };
+const fixed = { from: 100, to: 100, cycle: 0, isRoundTrip: false, easing: "fixed", easingAdd: "" };
+
+const makeCel = () => ({
+  x: { ...nonFixed },
+  y: { ...nonFixed },
+  scale: { ...nonFixed, from: 100, to: 100 },
+  opacity: { ...nonFixed, from: 0, to: 0 },
+  red: { ...fixed },
+  green: { ...fixed },
+  blue: { ...fixed },
+  tkSat: { ...fixed },
+  frame: { start: 1, volume: 10 },
+});
+
+const preloaded = {
+  celList: {
+    celIndex: 0,
+    selectedIndices: [0],
+    drawKey: 0,
+    list: [makeCel()],
+  },
+};
+
+describe("BulkConfigDialog", () => {
+  test("ダイアログが表示される", () => {
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: preloaded });
+    expect(screen.getByText("一括設定")).toBeInTheDocument();
+    expect(screen.getByText("上書き")).toBeInTheDocument();
+    expect(screen.getByText("加算")).toBeInTheDocument();
+    expect(screen.getByText("乗算")).toBeInTheDocument();
+  });
+
+  test("キャンセルで onClose が呼ばれ、状態は変わらない", () => {
+    const onClose = vi.fn();
+    const { store } = renderWithProviders(
+      <BulkConfigDialog onClose={onClose} />,
+      { preloadedState: preloaded }
+    );
+
+    userEvent.click(screen.getByText("キャンセル"));
+
+    expect(onClose).toBeCalled();
+    expect(store.getState().celList.list[0].x.from).toBe(10);
+  });
+
+  test("乗算に切り替えると入力値が全て 1 になる", () => {
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: preloaded });
+
+    userEvent.click(screen.getByText("乗算"));
+
+    const inputs = screen.getAllByRole("spinbutton");
+    inputs.forEach((input) => expect(input).toHaveValue(1));
+  });
+
+  test("加算に切り替えると入力値が全て 0 になる", () => {
+    renderWithProviders(<BulkConfigDialog onClose={vi.fn()} />, { preloadedState: preloaded });
+
+    userEvent.click(screen.getByText("乗算"));
+    userEvent.click(screen.getByText("加算"));
+
+    const inputs = screen.getAllByRole("spinbutton");
+    inputs.forEach((input) => expect(input).toHaveValue(0));
+  });
+
+  test("適用クリックで onClose が呼ばれる", () => {
+    const onClose = vi.fn();
+    renderWithProviders(<BulkConfigDialog onClose={onClose} />, { preloadedState: preloaded });
+
+    userEvent.click(screen.getByText("適用"));
+    expect(onClose).toBeCalled();
+  });
+
+  test("チェックをオンにしたパラメータだけ変更される", () => {
+    const { store } = renderWithProviders(
+      <BulkConfigDialog onClose={vi.fn()} />,
+      { preloadedState: preloaded }
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    userEvent.click(checkboxes[0]); // X のみオン
+
+    userEvent.click(screen.getByText("適用"));
+
+    // X は上書き 0 で更新される（from=0, to=0+(20-10)=10）
+    expect(store.getState().celList.list[0].x.from).toBe(0);
+    // Y は変わらない
+    expect(store.getState().celList.list[0].y.from).toBe(10);
+  });
+
+  test("オーバーレイクリックで onClose が呼ばれる", () => {
+    const onClose = vi.fn();
+    renderWithProviders(<BulkConfigDialog onClose={onClose} />, { preloadedState: preloaded });
+
+    userEvent.click(screen.getByTestId("bulk-config-overlay"));
+    expect(onClose).toBeCalled();
+  });
+});

--- a/src/component/Timeline.jsx
+++ b/src/component/Timeline.jsx
@@ -9,11 +9,12 @@ import {
   faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { addCel, copyCel, deleteCel, moveCelGroup, setCelIndex } from "../slice/celListSlice";
 import { setFrame } from "../slice/frameSlice";
 import TimeCelView from "./timeline/TimeCelView";
+import BulkConfigDialog from "./BulkConfigDialog";
 import { useTranslation } from "react-i18next";
 
 const FRAME_SIZE = 20;
@@ -34,6 +35,7 @@ export function Timeline({
 }) {
   const scrollRef = useRef(null);
   const { t } = useTranslation();
+  const [isBulkDialogOpen, setIsBulkDialogOpen] = useState(false);
 
   const baseList = [];
   for (let i = 0; i < maxFrame; i++) {
@@ -119,6 +121,12 @@ export function Timeline({
         >
           <FontAwesomeIcon icon={faSortDown} />
         </button>
+        <button
+          css={[styles.button, styles.bulkButton]}
+          onClick={() => setIsBulkDialogOpen(true)}
+        >
+          {t("timeline.bulkConfig")}
+        </button>
       </div>
       <div
         css={styles.wrapper}
@@ -183,6 +191,9 @@ export function Timeline({
           </div>
         </section>
       </div>
+      {isBulkDialogOpen && (
+        <BulkConfigDialog onClose={() => setIsBulkDialogOpen(false)} />
+      )}
     </div>
   );
 }
@@ -263,6 +274,9 @@ const styles = {
   sortButton: css`
     padding: 0.3em 0.5em 0.3em 0.5em;
     margin: 0 0.1em;
+  `,
+  bulkButton: css`
+    padding: 0.3em 0.8em;
   `,
   deleteButton: css`
     background: #e53935;

--- a/src/component/configs/FixedConfig.jsx
+++ b/src/component/configs/FixedConfig.jsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from "@emotion/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { updateFromTo } from "../../slice/celListSlice";
 import EasingConfig from "./FromTo/EasingConfig";
@@ -21,6 +21,7 @@ export function FixedConfig({
 }) {
   const [from, setFrom] = useState(config.from);
   const [key, setKey] = useState(Date.now());
+  const prevConfigFromRef = useRef(config.from);
 
   const reset = () => {
     setFrom(config.from);
@@ -36,6 +37,16 @@ export function FixedConfig({
   };
 
   useEffect(() => {
+    const configChanged = config.from !== prevConfigFromRef.current;
+    prevConfigFromRef.current = config.from;
+
+    if (configChanged) {
+      // 外部からの config 変更（一括設定・undo等）→ローカル値を config に同期
+      setFrom(config.from);
+      setKey(Date.now());
+      return;
+    }
+
     if (validate(from) && isChangeConfig(config, parseInt(from))) {
       updateFromTo(type, parseInt(from), config.to);
     }

--- a/src/component/configs/FromToConfig.jsx
+++ b/src/component/configs/FromToConfig.jsx
@@ -2,9 +2,7 @@
 
 import { css } from "@emotion/react";
 import { useDispatch, useSelector } from "react-redux";
-import { useEffect } from "react";
-import { useCallback } from "react";
-import { useState } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import { useConfigOption } from "../../hook/useConfigOption";
 import EasingConfig from "./FromTo/EasingConfig";
 import Options from "./FromTo/Options";
@@ -25,6 +23,7 @@ export function FromToConfig({
   const [from, setFrom] = useState(config.from);
   const [to, setTo] = useState(config.to);
   const [optionIsValid, setOptionIsValid] = useState(true);
+  const prevConfigRef = useRef({ from: config.from, to: config.to });
 
   const hasOption = () => {
     return config.cycle !== 0 || config.isRoundTrip;
@@ -48,6 +47,18 @@ export function FromToConfig({
   };
 
   useEffect(() => {
+    const configChanged =
+      config.from !== prevConfigRef.current.from ||
+      config.to !== prevConfigRef.current.to;
+    prevConfigRef.current = { from: config.from, to: config.to };
+
+    if (configChanged) {
+      // 外部からの config 変更（一括設定・undo等）→ローカル値を config に同期
+      setFrom(config.from);
+      setTo(config.to);
+      return;
+    }
+
     if (validateConfig(from, to)) {
       const intFrom = parseInt(from);
       const intTo = parseInt(to);

--- a/src/component/player/Controller.jsx
+++ b/src/component/player/Controller.jsx
@@ -84,9 +84,7 @@ export function Controller({
   };
 
   function playAnimation() {
-    if (frame >= maxFrameRef.current - 1) {
-      frameCounterRef.current = 0;
-    }
+    frameCounterRef.current = frame >= maxFrameRef.current - 1 ? 0 : frame;
     timeCounterRef.current = 0;
     prevTimeStampRef.current = undefined;
     isRunningRef.current = true;

--- a/src/component/player/Controller.test.jsx
+++ b/src/component/player/Controller.test.jsx
@@ -198,6 +198,49 @@ describe("2回目の再生", () => {
   });
 });
 
+describe("停止ボタンで先頭に戻した後の再生", () => {
+  test("最後まで自動再生された後に停止→再生しても、いきなり最終フレームに飛ばない", () => {
+    let animationCallback;
+    window.requestAnimationFrame.mockImplementation((cb) => {
+      animationCallback = cb;
+      return 1;
+    });
+
+    const mockSetFrame = vi.fn();
+    const { rerender } = render(
+      <Controller frame={19} maxFrame={20} setFrame={mockSetFrame} />
+    );
+
+    // リピート無しで最後まで自動再生され、内部カウンタが maxFrame-1 (19) で止まった状態を再現
+    userEvent.click(screen.getByTitle("play"));
+    act(() => {
+      animationCallback(0);
+    });
+    act(() => {
+      animationCallback(1000);
+    });
+
+    // 停止ボタン → Redux 側の frame は 0 になる想定（props を更新して再現）
+    userEvent.click(screen.getByTitle("stop"));
+    rerender(<Controller frame={0} maxFrame={20} setFrame={mockSetFrame} />);
+
+    // 再生ボタン
+    mockSetFrame.mockClear();
+    userEvent.click(screen.getByTitle("play"));
+
+    // 1フレーム分だけ時間を進める（最終フレームへ飛ぶバグがあれば setFrame(19) が呼ばれる）
+    act(() => {
+      animationCallback(0);
+    });
+    act(() => {
+      animationCallback(50);
+    });
+
+    expect(mockSetFrame).not.toBeCalledWith(19);
+    expect(mockSetFrame).toBeCalledWith(1);
+  });
+});
+
 describe("handleKeyDown", () => {
   describe("Left key down", () => {
     test("then call prevFrame", () => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,18 @@
     "header": "Timeline",
     "add": "New",
     "copy": "Copy",
-    "delete": "Delete"
+    "delete": "Delete",
+    "bulkConfig": "Bulk Settings"
+  },
+  "bulkConfigDialog": {
+    "title": "Bulk Settings",
+    "overwrite": "Overwrite",
+    "add": "Add",
+    "multiply": "Multiply",
+    "basic": "Basic",
+    "color": "Color",
+    "apply": "Apply",
+    "cancel": "Cancel"
   },
   "material": {
     "header": "Material Data",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,7 +14,8 @@
     "basic": "Basic",
     "color": "Color",
     "apply": "Apply",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "hsvMixed": "Color params (RGB/HSV) cannot be edited because HSV mode differs across selected cells."
   },
   "material": {
     "header": "Material Data",
@@ -133,7 +134,7 @@
       "hsvColor": "HSV Color",
       "hsvHue": "Hue",
       "hsvHueNote": "*range: 0–360",
-      "hsvSat": "Satulation",
+      "hsvSat": "S. Saturation",
       "hsvVal": "Value"
     }
   },

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -14,7 +14,8 @@
     "basic": "基本",
     "color": "色調",
     "apply": "適用",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "hsvMixed": "HSVモードが混在しているため、色調（RGB/HSV）は編集できません。"
   },
   "material": {
     "header": "素材データ",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -3,7 +3,18 @@
     "header": "タイムライン",
     "add": "追加",
     "copy": "コピー",
-    "delete": "削除"
+    "delete": "削除",
+    "bulkConfig": "一括設定"
+  },
+  "bulkConfigDialog": {
+    "title": "一括設定",
+    "overwrite": "上書き",
+    "add": "加算",
+    "multiply": "乗算",
+    "basic": "基本",
+    "color": "色調",
+    "apply": "適用",
+    "cancel": "キャンセル"
   },
   "material": {
     "header": "素材データ",

--- a/src/reducers/celParamReducers.js
+++ b/src/reducers/celParamReducers.js
@@ -78,6 +78,36 @@ export const updateEasing = (state, action) => {
     return cel;
   });
 };
+export const bulkUpdateParams = (state, action) => {
+  const { indices, params, updateType } = action.payload;
+  for (const idx of indices) {
+    const cel = state.list[idx];
+    if (!cel) continue;
+    for (const [key, value] of Object.entries(params)) {
+      const p = cel[key];
+      if (!p) continue;
+      switch (updateType) {
+        case "overwrite":
+          if (p.easing === "fixed") {
+            p.from = value;
+            p.to = value;
+          } else {
+            p.to = value + (p.to - p.from);
+            p.from = value;
+          }
+          break;
+        case "add":
+          p.from += value;
+          p.to += value;
+          break;
+        case "multiply":
+          p.from *= value;
+          p.to *= value;
+          break;
+      }
+    }
+  }
+};
 export const updateEasingOptions = (state, action) => {
   const { type, easing, value } = action.payload;
   // type: x.trig.amp みたいなやつ

--- a/src/reducers/celParamReducers.test.js
+++ b/src/reducers/celParamReducers.test.js
@@ -4,6 +4,7 @@ import reducer, {
   updateIsRoundTrip,
   updateEasing,
   updateEasingOptions,
+  bulkUpdateParams,
 } from "../slice/celListSlice";
 
 const baseParam = {
@@ -123,5 +124,76 @@ describe("updateEasingOptions", () => {
     }));
     expect(state.list[0].x.easingOptions.easeBack).toEqual({ overshoot: 1.7 });
     expect(state.list[0].x.easingOptions.easePoly).toEqual({ exponent: 2 });
+  });
+});
+
+describe("bulkUpdateParams", () => {
+  const nonFixed = { from: 10, to: 20, cycle: 0, isRoundTrip: false, easing: "easeLinear", easingAdd: "" };
+  const fixed = { from: 100, to: 100, cycle: 0, isRoundTrip: false, easing: "fixed", easingAdd: "" };
+
+  const bulkState = {
+    celIndex: 0,
+    drawKey: 0,
+    selectedIndices: [0],
+    list: [
+      { x: { ...nonFixed }, y: { ...nonFixed }, red: { ...fixed } },
+      { x: { ...nonFixed }, y: { ...nonFixed } },
+    ],
+  };
+
+  describe("上書き (overwrite)", () => {
+    test("non-fixed param: from = input, to = input + 元の差分", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { x: 50 }, updateType: "overwrite" }));
+      expect(state.list[0].x.from).toBe(50);
+      expect(state.list[0].x.to).toBe(60);
+    });
+    test("fixed param: from/to 両方が input 値になる", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { red: 150 }, updateType: "overwrite" }));
+      expect(state.list[0].red.from).toBe(150);
+      expect(state.list[0].red.to).toBe(150);
+    });
+    test("差分が 0 のとき from = to = input", () => {
+      const s = { ...bulkState, list: [{ x: { ...nonFixed, from: 10, to: 10 } }, ...bulkState.list.slice(1)] };
+      const state = reducer(s, bulkUpdateParams({ indices: [0], params: { x: 5 }, updateType: "overwrite" }));
+      expect(state.list[0].x.from).toBe(5);
+      expect(state.list[0].x.to).toBe(5);
+    });
+  });
+
+  describe("加算 (add)", () => {
+    test("from/to 両方に加算される", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { x: 5 }, updateType: "add" }));
+      expect(state.list[0].x.from).toBe(15);
+      expect(state.list[0].x.to).toBe(25);
+    });
+    test("マイナス値を加算できる", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { x: -3 }, updateType: "add" }));
+      expect(state.list[0].x.from).toBe(7);
+      expect(state.list[0].x.to).toBe(17);
+    });
+  });
+
+  describe("乗算 (multiply)", () => {
+    test("from/to 両方に乗算される", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { x: 2 }, updateType: "multiply" }));
+      expect(state.list[0].x.from).toBe(20);
+      expect(state.list[0].x.to).toBe(40);
+    });
+  });
+
+  describe("複数セルへの適用", () => {
+    test("indices の全セルに適用される", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0, 1], params: { x: 50 }, updateType: "overwrite" }));
+      expect(state.list[0].x.from).toBe(50);
+      expect(state.list[1].x.from).toBe(50);
+    });
+    test("indices に含まれないセルは変更されない", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { x: 50 }, updateType: "overwrite" }));
+      expect(state.list[1].x.from).toBe(10);
+    });
+    test("params に含まれないパラメータは変更されない", () => {
+      const state = reducer(bulkState, bulkUpdateParams({ indices: [0], params: { x: 50 }, updateType: "overwrite" }));
+      expect(state.list[0].y.from).toBe(10);
+    });
   });
 });

--- a/src/slice/celListSlice.js
+++ b/src/slice/celListSlice.js
@@ -118,6 +118,9 @@ export const celListSlice = createSlice({
       state.celIndex += 1;
       state.selectedIndices = [state.celIndex];
     },
+    selectAllCels: (state) => {
+      state.selectedIndices = state.list.map((_, i) => i);
+    },
     moveCelGroup: (state, action) => {
       const delta = parseInt(action.payload);
       if (delta === 0 || state.list.length < 2) return;
@@ -215,6 +218,7 @@ export const {
   copyCel,
   moveCel,
   moveCelGroup,
+  selectAllCels,
   updateFrame,
   updateFrameMultiple,
   updatePattern,
@@ -223,6 +227,7 @@ export const {
   updateIsRoundTrip,
   updateEasing,
   updateEasingOptions,
+  bulkUpdateParams,
   updateHSVMin,
   updateHSVMax,
   setIsHsv

--- a/src/slice/celListSlice.test.js
+++ b/src/slice/celListSlice.test.js
@@ -7,6 +7,7 @@ import reducer, {
   setCelName,
   moveCel,
   moveCelGroup,
+  selectAllCels,
   toggleSelectIndex,
   updateFrameMultiple,
   updateFromTo,
@@ -956,5 +957,23 @@ describe("loadCelList (selectedIndices 後方互換)", () => {
     };
     const state = reducer(undefined, loadCelList(data));
     expect(state.selectedIndices).toEqual([0, 2]);
+  });
+});
+
+describe("selectAllCels", () => {
+  test("全セルが selectedIndices に入る", () => {
+    const data = { celIndex: 0, selectedIndices: [0], drawKey: 0, list: [1, 2, 3] };
+    const state = reducer(data, selectAllCels());
+    expect(state.selectedIndices).toEqual([0, 1, 2]);
+  });
+  test("celIndex は変わらない", () => {
+    const data = { celIndex: 1, selectedIndices: [1], drawKey: 0, list: [1, 2, 3] };
+    const state = reducer(data, selectAllCels());
+    expect(state.celIndex).toBe(1);
+  });
+  test("セルが1つのとき selectedIndices = [0]", () => {
+    const data = { celIndex: 0, selectedIndices: [0], drawKey: 0, list: [1] };
+    const state = reducer(data, selectAllCels());
+    expect(state.selectedIndices).toEqual([0]);
   });
 });


### PR DESCRIPTION
## Summary
- タイムラインでCtrl+A全選択に対応
- 複数セル選択時に一括設定できるダイアログを追加（HSVモード対応含む）
- プレビューで停止→再生した際に最終フレームへジャンプしてしまう不具合を修正

## Test plan
- [x] npm test 全件通過
- [x] 動作確認済み（プレビュー停止→再生の等速再生を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A54uDdxbAhjpCBKRX6gZHv